### PR TITLE
Use prefixed route names in brand admin templates

### DIFF
--- a/Resources/views/Admin/Brand/create.html.twig
+++ b/Resources/views/Admin/Brand/create.html.twig
@@ -6,6 +6,6 @@
     {{ form_start(form, {'attr': {'class': 'ui form'}}) }}
         {{ form_widget(form) }}
         <button class="ui primary button" type="submit">Créer</button>
-        <a href="{{ path('admin_brand_index') }}" class="ui button">Retour</a>
+        <a href="{{ path('rika_sylius_brand_admin_brand_index') }}" class="ui button">Retour</a>
     {{ form_end(form) }}
 {% endblock %}

--- a/Resources/views/Admin/Brand/edit.html.twig
+++ b/Resources/views/Admin/Brand/edit.html.twig
@@ -6,6 +6,6 @@
     {{ form_start(form, {'attr': {'class': 'ui form'}}) }}
         {{ form_widget(form) }}
         <button class="ui primary button" type="submit">Enregistrer</button>
-        <a href="{{ path('admin_brand_index') }}" class="ui button">Retour</a>
+        <a href="{{ path('rika_sylius_brand_admin_brand_index') }}" class="ui button">Retour</a>
     {{ form_end(form) }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace legacy `admin_brand_index` route with `rika_sylius_brand_admin_brand_index` in brand create/edit templates
- Confirm brand admin templates use the prefixed route naming scheme

## Testing
- `composer validate`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction --no-progress` *(fails: curl error 56, CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b85cb6299c832881c0a3ad55766bb9