### PR TITLE
Add admin menu translation for brands

### DIFF
--- a/Resources/translations/messages.en.yaml
+++ b/Resources/translations/messages.en.yaml
@@ -9,6 +9,11 @@ rika_sylius_brand:
         no_logo: No logo
         position: Position
         products: Products
+        menu:
+            admin:
+                main:
+                    catalog:
+                        brands: Brands
     form:
         brand:
             code: Code

--- a/Resources/translations/messages.fr.yaml
+++ b/Resources/translations/messages.fr.yaml
@@ -9,11 +9,11 @@ rika_sylius_brand:
         no_logo: Pas de logo
         position: Position
         products: Produits
-    menu:
-        admin:
-            main:
-                catalog:
-                    brands: Marques  # Ajouté cette section !
+        menu:
+            admin:
+                main:
+                    catalog:
+                        brands: Marques
     form:
         brand:
             code: Code


### PR DESCRIPTION
## Summary
- add admin menu entry translation for brands in English and French
- verify translation keys stay in sync between languages

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b85cbdd06c83288800f53d15a4ed06