### PR TITLE
Fix brand logo upload and path handling

### DIFF
--- a/Resources/views/Shop/Brand/index.html.twig
+++ b/Resources/views/Shop/Brand/index.html.twig
@@ -7,7 +7,7 @@
     {% for brand in brands %}
         <div class="brand-item">
             {% if brand.logoPath %}
-                <img src="{{ asset(brand.logoPath) }}" alt="{{ brand.name }}">
+                <img src="{{ asset('media/brand/' ~ brand.logoPath) }}" alt="{{ brand.name }}">
             {% endif %}
             <h2><a href="{{ path('shop_brand_show', {slug: brand.translations|first.slug}) }}">
                 {{ brand.translations|first.name }}

--- a/Resources/views/Shop/Brand/show.html.twig
+++ b/Resources/views/Shop/Brand/show.html.twig
@@ -4,7 +4,7 @@
 <h1>{{ brand.translations|first.name }}</h1>
 
 {% if brand.logoPath %}
-    <img src="{{ asset(brand.logoPath) }}" alt="{{ brand.translations|first.name }}">
+    <img src="{{ asset('media/brand/' ~ brand.logoPath) }}" alt="{{ brand.translations|first.name }}">
 {% endif %}
 
 <p>{{ brand.translations|first.description }}</p>

--- a/src/EventListener/BrandEventListener.php
+++ b/src/EventListener/BrandEventListener.php
@@ -30,13 +30,17 @@ final class BrandEventListener implements EventSubscriberInterface
         $brand = $event->getSubject();
         $request = $this->requestStack->getCurrentRequest();
 
-        $file = $request->files->get('rika_sylius_brand_plugin')['logoPath'] ?? null;
+        if (null === $request) {
+            return;
+        }
+
+        $file = $request->files->get('rika_brand')['logoPath'] ?? null;
 
         if ($file) {
             $filename = uniqid().'.'.$file->guessExtension();
             try {
                 $file->move($this->uploadDir, $filename);
-                $brand->setLogoPath('/uploads/brands/'.$filename);
+                $brand->setLogoPath($filename);
             } catch (FileException $e) {
                 // Optionnel : loguer l'erreur
             }


### PR DESCRIPTION
## Summary
- Guard against null request before accessing files
- Save only logo filenames and move to configured upload directory
- Update brand templates to build logo URLs with `asset('media/brand/')`

## Testing
- `php -l src/EventListener/BrandEventListener.php`
- `composer validate --strict`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b85bd143508328b45a3382f399428f