### PR TITLE
fix: update brand translation keys in product form

### DIFF
--- a/src/Form/Extension/ProductTypeExtension.php
+++ b/src/Form/Extension/ProductTypeExtension.php
@@ -16,8 +16,8 @@ final class ProductTypeExtension extends AbstractTypeExtension
     {
         $builder->add('brand', BrandChoiceType::class, [
             'required' => false,
-            'label' => 'rika_sylius_brand_plugin.ui.brand',
-            'placeholder' => 'rika_sylius_brand_plugin.ui.choose_brand',
+            'label' => 'rika_sylius_brand.ui.brand',
+            'placeholder' => 'rika_sylius_brand.form.product.select_brand',
         ]);
     }
 


### PR DESCRIPTION
## Summary
- use `rika_sylius_brand` translation domain for brand fields in product form extension

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b85cbb9404832885bfcee377d2d046